### PR TITLE
Added fix for italic conversion skip

### DIFF
--- a/src/main/java/ca/codepit/tw2md/Main.java
+++ b/src/main/java/ca/codepit/tw2md/Main.java
@@ -547,6 +547,7 @@ public class Main implements Callable<Integer> {
 
 		// italic
 		s = s.replaceAll("([^:])//", "$1_");
+		s = s.replaceFirst("^//", "_");
 
 		// external links
 		s = s.replaceAll("\\[\\[([^|]+)\\|(http[^]]+)]]", "[$1]($2)");


### PR DESCRIPTION
Currently the italic syntax conversion skips the opening syntax for any string that begins with an italicized word. (Eg. on a new line, "//test//" turns into "//test_". 

Added an additional line that fixes this by replacing the first instance of `//`, when it's at the beginning of a string. Based on [this StackOverflow answer](https://stackoverflow.com/a/27920673) and the comment about needing `^` to replace only when at the beginning of a string (to avoid URL errors).