### PR TITLE
Fix/date tools tests

### DIFF
--- a/src/main/java/ca/codepit/tw2md/DateTools.java
+++ b/src/main/java/ca/codepit/tw2md/DateTools.java
@@ -1,30 +1,36 @@
 package ca.codepit.tw2md;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import org.yaml.snakeyaml.scanner.Constant;
+
 /**
  * @author evan
  */
 public class DateTools {
+	private static final String tiddlyWikiDateTimeFormat = "uuuuMMddHHmmssSSSXXXXX";
 
 	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
-					.ofPattern("uuuuMMddHHmmssSSSXXXXX");
+					.ofPattern(tiddlyWikiDateTimeFormat);
 
-	public static Optional<LocalDateTime> ts(String s) {
+	public static Optional<LocalDateTime> parseTiddlyWikiTimestampAsLocalDateTime(String tiddlyWikiTimestampUTC) {
 
-		return zts(s).map(ZonedDateTime::toLocalDateTime);
+		return parseTiddlyWikiTimestampAsSystemZonedDateTime(tiddlyWikiTimestampUTC).map(ZonedDateTime::toLocalDateTime);
 	}
 
-	public static Optional<ZonedDateTime> zts(String s) {
+	public static Optional<ZonedDateTime> parseTiddlyWikiTimestampAsSystemZonedDateTime(String tiddlyWikiTimestamp) {
 
 		try {
-			ZonedDateTime zdtInstanceAtOffset = ZonedDateTime.parse(s + "+00:00", DATE_TIME_FORMATTER);
-			ZonedDateTime zdtInstanceAtUTC = zdtInstanceAtOffset.withZoneSameInstant(ZoneOffset.systemDefault());
-			return Optional.of(zdtInstanceAtUTC);
+			ZonedDateTime zonedDateTimeInstanceUTC = ZonedDateTime.parse(tiddlyWikiTimestamp + "+00:00", DATE_TIME_FORMATTER);
+
+			ZonedDateTime zonedDateTimeInstanceLocalizedToComputer = zonedDateTimeInstanceUTC.withZoneSameInstant(ZoneOffset.systemDefault());
+
+			return Optional.of(zonedDateTimeInstanceLocalizedToComputer);
 		} catch (Exception e) {
 			return Optional.empty();
 		}

--- a/src/main/java/ca/codepit/tw2md/Tiddler.java
+++ b/src/main/java/ca/codepit/tw2md/Tiddler.java
@@ -26,10 +26,10 @@ class Tiddler {
 		this.body = body;
 
 		this.createdTime = Optional.ofNullable(headers.get("created"))
-						.flatMap(DateTools::zts);
+						.flatMap(DateTools::parseTiddlyWikiTimestampAsSystemZonedDateTime);
 
 		this.lastUpdatedTime = Optional.ofNullable(headers.get("modified"))
-						.flatMap(DateTools::zts);
+						.flatMap(DateTools::parseTiddlyWikiTimestampAsSystemZonedDateTime);
 	}
 
 	public String getHeader(String key) {

--- a/src/test/java/ca/codepit/tw2md/DateToolsTest.java
+++ b/src/test/java/ca/codepit/tw2md/DateToolsTest.java
@@ -3,6 +3,8 @@ package ca.codepit.tw2md;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,10 +16,17 @@ class DateToolsTest {
 
 	@Test
 	public void canParseATiddlyWikiTimestamp() {
+		// Timestamp is always UTC, see https://en.wikipedia.org/wiki/Unix_time
+		//
+		// We explicitely convert first to ZonedDateTime UTC to avoid broken test 
+		// thanks to timezone differences between devs computers around the world.
+		final String tiddlyWikiTimestampInUTC = "20210920015946441";
+		final ZonedDateTime expectedUTCZonedDateTime = ZonedDateTime.of(LocalDateTime.of(2021, 9, 20, 01, 59, 46, 441 * 1000000), ZoneId.of("UTC"));
 
-		final LocalDateTime expected = LocalDateTime.of(2021, 9, 19, 21, 59, 46, 441 * 1000000);
-		final Optional<LocalDateTime> ts = DateTools.ts("20210920015946441");
-		assertEquals(Optional.of(expected), ts);
+
+		final LocalDateTime expectedLocalDateTimeOnSystemTimeZone = expectedUTCZonedDateTime.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+		final Optional<LocalDateTime> parsedTiddlyWikiTimestampAsLocalDateTimeOnSystemTimeZone = DateTools.parseTiddlyWikiTimestampAsLocalDateTime(tiddlyWikiTimestampInUTC);
+		assertEquals(Optional.of(expectedLocalDateTimeOnSystemTimeZone), parsedTiddlyWikiTimestampAsLocalDateTimeOnSystemTimeZone);
 	}
 
 }


### PR DESCRIPTION
The tests crashed on my computer when I first ran them.

It is related to an issue with timezone differences in a test of DateTools class.

The solution was to reproduce the behavior of the DateTools methods in the test to avoid being tied to a particular computer's system timezone.

I added very explicit naming because working with date and timezone is hard.